### PR TITLE
feat: implement 7-bag randomizer

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -228,7 +228,7 @@
     }
     state.can-hold = true
     state.current = state.next
-   (state.rng, state.mino-bag, state.next) = new-mino(state.rng, state.mino-bag, cols, rows)
+    (state.rng, state.mino-bag, state.next) = new-mino(state.rng, state.mino-bag, cols, rows)
   }
   state
 }

--- a/lib.typ
+++ b/lib.typ
@@ -228,10 +228,7 @@
     }
     state.can-hold = true
     state.current = state.next
-  let (rng-after-draw, bag-after-draw, next-mino) = new-mino(state.rng, state.mino-bag, cols, rows)
-  state.rng = rng-after-draw
-  state.mino-bag = bag-after-draw
-  state.next = next-mino
+   (state.rng, state.mino-bag, state.next) = new-mino(state.rng, state.mino-bag, cols, rows)
   }
   state
 }

--- a/lib.typ
+++ b/lib.typ
@@ -125,10 +125,7 @@
   if state.hold == none {
     state.hold = create-mino(minoes.at(state.current.index), cols, rows)
     state.current = state.next
-  let (rng-after-draw, bag-after-draw, next-mino) = new-mino(state.rng, state.mino-bag, cols, rows)
-  state.rng = rng-after-draw
-  state.mino-bag = bag-after-draw
-  state.next = next-mino
+    (state.rng, state.mino-bag, state.next) = new-mino(state.rng, state.mino-bag, cols, rows)
   } else {
     let hold-mino = state.hold
     state.hold = create-mino(minoes.at(state.current.index), cols, rows)

--- a/lib.typ
+++ b/lib.typ
@@ -270,19 +270,8 @@
     can-hold: true,
   )
 
-  let (rng-after-current-draw, bag-after-current-draw, current-mino) = new-mino(rng-after-initial-bag, bag-after-initial-bag, cols, rows)
-  let (rng-after-next-draw, bag-after-next-draw, next-mino) = new-mino(rng-after-current-draw, bag-after-current-draw, cols, rows)
-  let state = (
-    rng: rng-after-next-draw,
-    mino-bag: bag-after-next-draw,
-    current: current-mino,
-    next: next-mino,
-    map: range(rows + 4).map(_ => range(cols).map(it => "_")),
-    end: false,
-    score: 0,
-    hold: none,
-    can-hold: true,
-  )
+  (state.rng, state.mino-bag, state.current) = new-mino(rng-after-initial-bag, bag-after-initial-bag, cols, rows)
+  (state.rng, state.mino-bag, state.next) = new-mino(state.rng, state.mino-bag, cols, rows)
 
   for char in chars {
     if actions.left.any(it => it == char) {

--- a/lib.typ
+++ b/lib.typ
@@ -1,4 +1,4 @@
-#import "@preview/suiji:0.3.0": gen-rng, choice
+#import "@preview/suiji:0.3.0": gen-rng, choice, shuffle
 #import "mino/tetris.typ": render-field
 
 #let parse-actions(body) = {
@@ -17,6 +17,12 @@
 
 #let minoes = (("ZZ_", "_ZZ"), ("OO", "OO"), ("_SS", "SS_"), ("IIII",), ("__L", "LLL"), ("J__", "JJJ"), ("_T_", "TTT"))
 
+#let shuffle-minoes(rng) = {
+  let indices = range(minoes.len())
+  let (rng-after-shuffle, shuffled) = shuffle(rng, indices)
+  (rng-after-shuffle, shuffled.map(i => minoes.at(i)))
+}
+
 #let create-mino(mino, cols, rows) = {
   let width = calc.max(..mino.map(it => it.len()))
   (
@@ -28,10 +34,21 @@
   )
 }
 
-#let new-mino(rng, cols, rows) = {
-  let (rng, mino) = choice(rng, minoes)
-  let width = calc.max(..mino.map(it => it.len()))
-  (rng, create-mino(mino, cols, rows))
+#let new-mino(rng, bag, cols, rows) = {
+  let mino-bag = bag
+  let rng-before-draw = rng
+  let mino = none
+  let bag-before-draw = mino-bag
+  let rng-after-bag = rng-before-draw
+  let bag-after-bag = bag-before-draw
+  if mino-bag.len() == 0 {
+    let (rng-after-shuffle, new-bag) = shuffle-minoes(rng-before-draw)
+    bag-after-bag = new-bag
+    rng-after-bag = rng-after-shuffle
+  }
+  mino = bag-after-bag.at(0)
+  let bag-after-draw = bag-after-bag.slice(1, bag-after-bag.len())
+  (rng-after-bag, bag-after-draw, create-mino(mino, cols, rows))
 }
 
 #let render-map(map, bg-color: rgb("#f3f3ed")) = {
@@ -108,7 +125,10 @@
   if state.hold == none {
     state.hold = create-mino(minoes.at(state.current.index), cols, rows)
     state.current = state.next
-    (state.rng, state.next) = new-mino(state.rng, cols, rows)
+  let (rng-after-draw, bag-after-draw, next-mino) = new-mino(state.rng, state.mino-bag, cols, rows)
+  state.rng = rng-after-draw
+  state.mino-bag = bag-after-draw
+  state.next = next-mino
   } else {
     let hold-mino = state.hold
     state.hold = create-mino(minoes.at(state.current.index), cols, rows)
@@ -211,7 +231,10 @@
     }
     state.can-hold = true
     state.current = state.next
-    (state.rng, state.next) = new-mino(state.rng, cols, rows)
+  let (rng-after-draw, bag-after-draw, next-mino) = new-mino(state.rng, state.mino-bag, cols, rows)
+  state.rng = rng-after-draw
+  state.mino-bag = bag-after-draw
+  state.next = next-mino
   }
   state
 }
@@ -239,8 +262,11 @@
 
   let chars = parse-actions(body)
 
+  let rng-initial = gen-rng(seed)
+  let (rng-after-initial-bag, bag-after-initial-bag) = shuffle-minoes(rng-initial)
   let state = (
-    rng: gen-rng(seed),
+    rng: rng-after-initial-bag,
+    mino-bag: bag-after-initial-bag,
     current: none,
     next: none,
     map: range(rows + 4).map(_ => range(cols).map(it => "_")),
@@ -250,8 +276,19 @@
     can-hold: true,
   )
 
-  (state.rng, state.current) = new-mino(state.rng, cols, rows)
-  (state.rng, state.next) = new-mino(state.rng, cols, rows)
+  let (rng-after-current-draw, bag-after-current-draw, current-mino) = new-mino(rng-after-initial-bag, bag-after-initial-bag, cols, rows)
+  let (rng-after-next-draw, bag-after-next-draw, next-mino) = new-mino(rng-after-current-draw, bag-after-current-draw, cols, rows)
+  let state = (
+    rng: rng-after-next-draw,
+    mino-bag: bag-after-next-draw,
+    current: current-mino,
+    next: next-mino,
+    map: range(rows + 4).map(_ => range(cols).map(it => "_")),
+    end: false,
+    score: 0,
+    hold: none,
+    can-hold: true,
+  )
 
   for char in chars {
     if actions.left.any(it => it == char) {


### PR DESCRIPTION
This pull request updates the Tetris logic in `lib.typ` to implement 7-bag randomizer system for mino selection, replacing the previous simple random choice.

This change ensures that all mino types are distributed more evenly, improving game fairness and aligning with standard modern Tetris mechanics.

```typ
// #import "@preview/soviet-matrix:0.2.0": game
#import "../lib.typ": game
#show: game.with(seed: 2)

/*
Move Left: a
Move Right: d
Soft Drop: s
Hard Drop: f
Rotate Left: q
Rotate Right: e
180-degree Rotate: w
Hold Piece: c

Enter characters below to get started.
*/
aaafcqdfcddefefddddeffaaaefedddddfcedddddfqafdf
```

<img width="486" height="564" alt="image" src="https://github.com/user-attachments/assets/55f82c1a-0718-471d-8fa9-feaa39a622dc" />
